### PR TITLE
Add Deletion of empty orgs and sightings

### DIFF
--- a/src/main/java/com/e/superherosightings/controllers/HeroController.java
+++ b/src/main/java/com/e/superherosightings/controllers/HeroController.java
@@ -13,6 +13,7 @@ import com.e.superherosightings.dao.SuperpowerDao;
 import com.e.superherosightings.dto.Hero;
 import com.e.superherosightings.dto.Location;
 import com.e.superherosightings.dto.Organization;
+import com.e.superherosightings.dto.Sighting;
 import com.e.superherosightings.dto.Superpower;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
@@ -92,6 +93,22 @@ public class HeroController {
     
     @GetMapping("deleteHero")
     public String deleteHero(Integer id){
+        Hero hero = heroDao.getHeroById(id);
+        
+        List<Organization> orgs = organizationDao.getOrganizationsForHero(hero);
+        for(Organization org : orgs){
+            if(org.getHeroes().size() <= 1){
+                organizationDao.deleteOrganization(org.getId());
+            }
+        }
+        
+        List<Sighting> sightings  = sightingDao.getSightingsForHero(hero);
+        for(Sighting sighting : sightings){
+            if(sighting.getHeroes().size() <= 1){
+                sightingDao.deleteSighting(sighting.getId());
+            }
+        }
+        
         heroDao.deleteHero(id);
         return "redirect:/heroes";
     }

--- a/src/main/java/com/e/superherosightings/dao/SightingDao.java
+++ b/src/main/java/com/e/superherosightings/dao/SightingDao.java
@@ -5,6 +5,7 @@
  */
 package com.e.superherosightings.dao;
 
+import com.e.superherosightings.dto.Hero;
 import com.e.superherosightings.dto.Sighting;
 import java.time.LocalDate;
 import java.util.List;
@@ -20,6 +21,7 @@ public interface SightingDao {
     void updateSighting(Sighting sighting);
     void deleteSighting(int id);
     
+    List<Sighting> getSightingsForHero(Hero hero);
     List<Sighting> getSightingsForDate(LocalDate date);
     List<Sighting> getLastTenSightings();
 }

--- a/src/main/java/com/e/superherosightings/dao/SightingDaoDB.java
+++ b/src/main/java/com/e/superherosightings/dao/SightingDaoDB.java
@@ -132,6 +132,16 @@ public class SightingDaoDB implements SightingDao{
     }
     
     @Override
+    public List<Sighting> getSightingsForHero(Hero hero){
+        final String SELECT_SIGHTING_FOR_HERO = "SELECT * FROM sighting "
+                + "JOIN heroSighting hs ON hs.sightingId = sighting.id "
+                + "WHERE hs.heroId = ?";
+        List<Sighting> sightings = jdbc.query(SELECT_SIGHTING_FOR_HERO, new SightingMapper(), hero.getId());
+        associateHeroesAndLocation(sightings);
+        return sightings;
+    }
+    
+    @Override
     public List<Sighting> getSightingsForDate(LocalDate date){
         final String SELECT_SIGHTINGS_FOR_DATE = "SELECT * FROM sighting WHERE date = ?;";
         List<Sighting> sightings = jdbc.query(SELECT_SIGHTINGS_FOR_DATE, new SightingMapper(), date);


### PR DESCRIPTION
Changes:
* Added `getSightingsForHero(Hero hero)` to `SightingDao`
* `deleteHero(Integer id)` now deletes related Organizations and Sightings if the last Hero in their respective Lists is being deleted